### PR TITLE
Added simple preview to chatGPT

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -1,0 +1,38 @@
+from typing import Any, TypedDict
+
+
+class Params(TypedDict):
+    pass
+
+
+class Result(TypedDict):
+    preview: Any
+
+class Preview(TypedDict):
+    latex: str
+    sympy: str
+    feedback: str
+
+
+
+def preview_function(response: Any, params: Params) -> Result:
+    """
+    Function used to preview a student response.
+    ---
+    The handler function passes three arguments to preview_function():
+
+    - `response` which are the answers provided by the student.
+    - `params` which are any extra parameters that may be useful,
+        e.g., error tolerances.
+
+    The output of this function is what is returned as the API response
+    and therefore must be JSON-encodable. It must also conform to the
+    response schema.
+
+    Any standard python library may be used, as well as any package
+    available on pip (provided it is added to requirements.txt).
+
+    The way you wish to structure you code (all in this function, or
+    split into many) is entirely up to you.
+    """
+    return Result(preview=Preview(latex=response, sympy=response))

--- a/app/preview_tests.py
+++ b/app/preview_tests.py
@@ -1,0 +1,39 @@
+import unittest
+
+try:
+    from .preview import Params, preview_function
+except ImportError:
+    from preview import Params, preview_function
+
+
+class TestPreviewFunction(unittest.TestCase):
+    """
+    TestCase Class used to test the algorithm.
+    ---
+    Tests are used here to check that the algorithm written
+    is working as it should.
+
+    It's best practice to write these tests first to get a
+    kind of 'specification' for how your algorithm should
+    work, and you should run these tests before committing
+    your code to AWS.
+
+    Read the docs on how to use unittest here:
+    https://docs.python.org/3/library/unittest.html
+
+    Use preview_function() to check your algorithm works
+    as it should.
+    """
+
+    def test_returns_preview_key(self):
+        response, params = "test", Params()
+        result = preview_function(response, params)
+
+        self.assertIn("preview", result)
+        self.assertIsNotNone(result["preview"])
+        self.assertEqual(result["preview"]["latex"], "test")
+        self.assertEqual(result["preview"]["sympy"], "test")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Problem:** The Evaluation Function did not have a preview function.

**Fix:**
- Implemented a simple preview function that returns the input (see `preview.py` and tests in `preview_tests.py`).
